### PR TITLE
fix: stop pipeline retrieval upon reaching limit

### DIFF
--- a/helpers/circleci.py
+++ b/helpers/circleci.py
@@ -83,7 +83,7 @@ class CircleCI(object):
             if containing_workflows or not_containing_workflows or successful_only:
                 for pipeline in filtered_pipelines:
                     # Don't retrieve more than `limit` matching pipelines if limit is enforced
-                    if limit is not None and len(retrieved_pipelines) > limit:
+                    if limit is not None and len(retrieved_pipelines) >= limit:
                         found_stopping_pipeline = True
                         break
                     # Verify matching conditions


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR fixes an issue that caused the scheduler to retrieve more pipelines than necessary, even when the `limit` condition was already met.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
